### PR TITLE
Add prefs CLI for managing dyk-prefs.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@
 !tagging/tagging-guide.md
 !tagging/tags.csv
 !tagging/dyk-prefs.json
+
+# Docs
+!docs/
+!docs/plans/
+!docs/plans/*.md

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 !scripts/serve_hook.py
 !scripts/fetch_hooks.py
 !scripts/write_tags.py
+!scripts/prefs.py
 
 # Tests
 !tests/
@@ -29,6 +30,7 @@
 !tests/test_serve_hook.py
 !tests/test_fetch_hooks.py
 !tests/test_write_tags.py
+!tests/test_prefs.py
 
 # Tagging
 !tagging/

--- a/SKILL.md
+++ b/SKILL.md
@@ -18,7 +18,7 @@ When invoked, the default behaviour is to share the next fact from the queue:
 python3 {baseDir}/scripts/dyk.py
 ```
 
-Prints one fact:
+Prints one fact. Return it to the user verbatim:
 
 ```
 Did you know that heavy-metal guitarist Kiki Wong played drums for Taylor Swift before joining the Smashing Pumpkins?
@@ -48,6 +48,7 @@ openclaw cron add \
   --name "DYK refresh" \
   --every 12h \
   --session isolated \
+  --channel none \
   --message "Refresh the DYK cache and tag new hooks"
 ```
 

--- a/docs/plans/2026-03-08-prefs-cli-design.md
+++ b/docs/plans/2026-03-08-prefs-cli-design.md
@@ -1,0 +1,54 @@
+# Prefs CLI Design
+
+## Goal
+
+A deterministic command-line interface for reading and writing `dyk-prefs.json`, intended for use by an LLM managing user preferences based on hook reactions.
+
+## Why a CLI rather than direct JSON editing
+
+Direct JSON editing by an LLM is fragile. A dedicated CLI allows us to enshrine validation rules and guardrails: unknown tags are rejected, values are constrained to a fixed vocabulary, and the file is written atomically. The LLM calls commands; it never touches the JSON itself.
+
+## Commands
+
+```
+prefs.py init
+prefs.py list
+prefs.py get <dimension> <tag>
+prefs.py set <dimension> <tag> <like|neutral|dislike>
+```
+
+## Value vocabulary
+
+| Word | Stored value |
+|---|---|
+| `like` | `1` |
+| `neutral` | `0` |
+| `dislike` | `-1` |
+
+Words rather than numbers prevent an LLM from passing out-of-range values by accident.
+
+## Validation
+
+- Dimension must be known (loaded from `tags.csv`)
+- Tag must exist within that dimension
+- Value must be one of `like`, `neutral`, `dislike`
+
+Vocabulary is loaded from the same `tags.csv` used by `write_tags.py`, so the CLI stays in sync automatically as new dimensions/tags are added.
+
+## Behaviour
+
+**`init`** — if `dyk-prefs.json` already exists, print a message and exit 1. Otherwise write the full prefs structure (all values `0`) to `PREFS_PATH` and exit 0.
+
+**`list`** — pretty-print current prefs grouped by dimension. Suggests `init` if file is missing.
+
+**`get`** — print the word (`like`/`neutral`/`dislike`) for the given dimension/tag. Suggests `init` if file is missing.
+
+**`set`** — validate dimension/tag/value, update the single value, save atomically using the same write-to-temp-then-rename pattern as `helpers.save_store`. Print confirmation.
+
+## Error handling
+
+All validation failures and missing-file conditions exit 1 with a clear message. No silent failures.
+
+## File location
+
+`scripts/prefs.py` — consistent with `fetch_hooks.py`, `write_tags.py`, `serve_hook.py`.

--- a/docs/plans/2026-03-08-prefs-cli.md
+++ b/docs/plans/2026-03-08-prefs-cli.md
@@ -1,0 +1,636 @@
+# Prefs CLI Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build `scripts/prefs.py` — a validated CLI for reading and writing `dyk-prefs.json` — with four commands: `init`, `list`, `get`, `set`.
+
+**Architecture:** A standalone script alongside `fetch_hooks.py`, `write_tags.py`, etc. Loads tag vocabulary from `tags.csv` (reusing `write_tags.load_vocabulary`) for validation. Reads/writes prefs via `helpers.PREFS_PATH` using atomic write (write-to-temp + rename, same pattern as `helpers.save_store`). Values are expressed as words (`like`/`neutral`/`dislike`) mapped to integers (`1`/`0`/`-1`).
+
+**Tech Stack:** Python 3 stdlib only (`argparse`, `json`, `csv`, `pathlib`). `pytest` for tests.
+
+---
+
+### Context: key files to understand before starting
+
+- `scripts/helpers.py` — `PREFS_PATH`, `load_prefs()`, `save_store()` (atomic write pattern to copy)
+- `scripts/write_tags.py` — `load_vocabulary()` to reuse for tag validation
+- `tagging/tags.csv` — vocabulary source; columns `tag_id`, `dimension`, `description`
+- `tagging/dyk-prefs.json` — example prefs file (used by `init` as the template structure)
+- `tests/test_write_tags.py` — reference for test style (helper factories, `tmp_path`, `monkeypatch`)
+
+### Context: `.gitignore` is a deny-all whitelist
+
+New files must be explicitly whitelisted. After creating `scripts/prefs.py` and `tests/test_prefs.py`, add them to `.gitignore`.
+
+---
+
+### Task 1: Whitelist new files in `.gitignore`
+
+**Files:**
+- Modify: `.gitignore`
+
+**Step 1: Add entries**
+
+In `.gitignore`, add to the `# Source` block:
+```
+!scripts/prefs.py
+```
+
+And to the `# Tests` block:
+```
+!tests/test_prefs.py
+```
+
+**Step 2: Verify**
+
+```bash
+git status
+```
+Expected: `.gitignore` appears as modified, no untracked files complained about yet.
+
+**Step 3: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore: whitelist scripts/prefs.py and tests/test_prefs.py"
+```
+
+---
+
+### Task 2: Scaffold `scripts/prefs.py` with `init` command
+
+**Files:**
+- Create: `scripts/prefs.py`
+- Create: `tests/test_prefs.py`
+
+The `init` command writes the full prefs structure (all values `0`) to `PREFS_PATH`, refusing if the file already exists.
+
+**Step 1: Write the failing test**
+
+Create `tests/test_prefs.py`:
+
+```python
+#!/usr/bin/env python3
+"""Unit tests for scripts/prefs.py.
+
+Run with: python3 -m pytest tests/ -v
+Requires: pip install pytest
+"""
+import csv
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import prefs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_vocab_csv(tmp_path):
+    rows = [
+        ("history",    "domain", "History"),
+        ("science",    "domain", "Science"),
+        ("surprising", "tone",   "Surprising"),
+        ("straight",   "tone",   "Straight"),
+    ]
+    p = tmp_path / "tags.csv"
+    with p.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["tag_id", "dimension", "description"])
+        writer.writerows(rows)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+
+def test_init_creates_file(tmp_path, monkeypatch):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["init"])
+
+    assert result == 0
+    data = json.loads(prefs_path.read_text())
+    assert data == {"domain": {"history": 0, "science": 0}, "tone": {"surprising": 0, "straight": 0}}
+
+
+def test_init_refuses_if_file_exists(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    prefs_path.write_text("{}")
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["init"])
+
+    assert result == 1
+    assert "already exists" in capsys.readouterr().err
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+python3 -m pytest tests/test_prefs.py -v
+```
+Expected: `ModuleNotFoundError: No module named 'prefs'`
+
+**Step 3: Create `scripts/prefs.py` with `init`**
+
+```python
+#!/usr/bin/env python3
+"""CLI for reading and writing dyk-prefs.json."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from write_tags import load_vocabulary
+from helpers import PREFS_PATH
+
+TAGS_CSV = Path(__file__).parent.parent / "tagging" / "tags.csv"
+
+VALUE_MAP = {"like": 1, "neutral": 0, "dislike": -1}
+VALUE_MAP_INV = {v: k for k, v in VALUE_MAP.items()}
+
+
+def _load_vocab() -> dict[str, set[str]]:
+    return load_vocabulary(TAGS_CSV)
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    try:
+        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.rename(path)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    if PREFS_PATH.exists():
+        print(f"dyk-prefs.json already exists at {PREFS_PATH}", file=sys.stderr)
+        return 1
+    vocab = _load_vocab()
+    data = {dim: {tag: 0 for tag in sorted(tags)} for dim, tags in sorted(vocab.items())}
+    _atomic_write(PREFS_PATH, data)
+    print(f"Created {PREFS_PATH}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Manage DYK preferences.")
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("init", help="Create prefs file (fails if already exists)")
+    args = parser.parse_args(argv)
+    if args.command is None:
+        parser.print_help()
+        return 1
+    if args.command == "init":
+        return cmd_init(args)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+**Step 4: Run tests**
+
+```bash
+python3 -m pytest tests/test_prefs.py -v
+```
+Expected: 2 tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/prefs.py tests/test_prefs.py
+git commit -m "feat: add prefs.py with init command"
+```
+
+---
+
+### Task 3: Add `list` command
+
+**Files:**
+- Modify: `scripts/prefs.py`
+- Modify: `tests/test_prefs.py`
+
+**Step 1: Write failing tests**
+
+Add to `tests/test_prefs.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+def _write_prefs(path, data):
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_list_prints_prefs(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 1, "science": -1}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["list"])
+
+    out = capsys.readouterr().out
+    assert result == 0
+    assert "history" in out
+    assert "like" in out
+    assert "science" in out
+    assert "dislike" in out
+
+
+def test_list_missing_file_suggests_init(tmp_path, monkeypatch, capsys):
+    prefs_path = tmp_path / "dyk-prefs.json"
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+
+    result = prefs.main(["list"])
+
+    assert result == 1
+    assert "init" in capsys.readouterr().err
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+python3 -m pytest tests/test_prefs.py::test_list_prints_prefs tests/test_prefs.py::test_list_missing_file_suggests_init -v
+```
+Expected: FAIL (unknown command).
+
+**Step 3: Implement `list`**
+
+Add to `scripts/prefs.py`:
+
+```python
+def cmd_list(args: argparse.Namespace) -> int:
+    if not PREFS_PATH.exists():
+        print(f"No prefs file found. Run: prefs.py init", file=sys.stderr)
+        return 1
+    try:
+        data = json.loads(PREFS_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Cannot read prefs: {exc}", file=sys.stderr)
+        return 1
+    for dim, tags in sorted(data.items()):
+        print(f"{dim}:")
+        for tag, val in sorted(tags.items()):
+            word = VALUE_MAP_INV.get(val, str(val))
+            print(f"  {tag}: {word}")
+    return 0
+```
+
+And wire it into `main()`:
+
+```python
+    sub.add_parser("list", help="Show all current preferences")
+    # ...
+    if args.command == "list":
+        return cmd_list(args)
+```
+
+**Step 4: Run tests**
+
+```bash
+python3 -m pytest tests/test_prefs.py -v
+```
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/prefs.py tests/test_prefs.py
+git commit -m "feat: add list command to prefs CLI"
+```
+
+---
+
+### Task 4: Add `get` command
+
+**Files:**
+- Modify: `scripts/prefs.py`
+- Modify: `tests/test_prefs.py`
+
+**Step 1: Write failing tests**
+
+Add to `tests/test_prefs.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+def test_get_returns_word(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 1}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["get", "domain", "history"])
+
+    assert result == 0
+    assert "like" in capsys.readouterr().out
+
+
+def test_get_unknown_dimension(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["get", "badDim", "history"])
+
+    assert result == 1
+    assert "Unknown dimension" in capsys.readouterr().err
+
+
+def test_get_unknown_tag(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["get", "domain", "badTag"])
+
+    assert result == 1
+    assert "Unknown tag" in capsys.readouterr().err
+
+
+def test_get_missing_file_suggests_init(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["get", "domain", "history"])
+
+    assert result == 1
+    assert "init" in capsys.readouterr().err
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+python3 -m pytest tests/test_prefs.py::test_get_returns_word -v
+```
+Expected: FAIL.
+
+**Step 3: Implement `get`**
+
+Add to `scripts/prefs.py`:
+
+```python
+def cmd_get(args: argparse.Namespace) -> int:
+    if not PREFS_PATH.exists():
+        print(f"No prefs file found. Run: prefs.py init", file=sys.stderr)
+        return 1
+    vocab = _load_vocab()
+    if args.dimension not in vocab:
+        print(f"Unknown dimension: {args.dimension!r}. Valid: {sorted(vocab)}", file=sys.stderr)
+        return 1
+    if args.tag not in vocab[args.dimension]:
+        print(f"Unknown tag: {args.tag!r}. Valid for {args.dimension!r}: {sorted(vocab[args.dimension])}", file=sys.stderr)
+        return 1
+    try:
+        data = json.loads(PREFS_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Cannot read prefs: {exc}", file=sys.stderr)
+        return 1
+    val = (data.get(args.dimension) or {}).get(args.tag, 0)
+    print(VALUE_MAP_INV.get(val, str(val)))
+    return 0
+```
+
+Wire into `main()`:
+
+```python
+    get_p = sub.add_parser("get", help="Get preference for a tag")
+    get_p.add_argument("dimension")
+    get_p.add_argument("tag")
+    # ...
+    if args.command == "get":
+        return cmd_get(args)
+```
+
+**Step 4: Run tests**
+
+```bash
+python3 -m pytest tests/test_prefs.py -v
+```
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/prefs.py tests/test_prefs.py
+git commit -m "feat: add get command to prefs CLI"
+```
+
+---
+
+### Task 5: Add `set` command
+
+**Files:**
+- Modify: `scripts/prefs.py`
+- Modify: `tests/test_prefs.py`
+
+**Step 1: Write failing tests**
+
+Add to `tests/test_prefs.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# set
+# ---------------------------------------------------------------------------
+
+def test_set_updates_value(tmp_path, monkeypatch):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0, "science": 0}, "tone": {"straight": 0, "surprising": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["set", "domain", "history", "like"])
+
+    assert result == 0
+    data = json.loads(prefs_path.read_text())
+    assert data["domain"]["history"] == 1
+    assert data["domain"]["science"] == 0  # untouched
+
+
+def test_set_dislike(tmp_path, monkeypatch):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["set", "domain", "history", "dislike"])
+
+    assert result == 0
+    data = json.loads(prefs_path.read_text())
+    assert data["domain"]["history"] == -1
+
+
+def test_set_invalid_value(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["set", "domain", "history", "love"])
+
+    assert result == 1
+    assert "like" in capsys.readouterr().err
+
+
+def test_set_unknown_dimension(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["set", "badDim", "history", "like"])
+
+    assert result == 1
+    assert "Unknown dimension" in capsys.readouterr().err
+
+
+def test_set_unknown_tag(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["set", "domain", "badTag", "like"])
+
+    assert result == 1
+    assert "Unknown tag" in capsys.readouterr().err
+
+
+def test_set_missing_file_suggests_init(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["set", "domain", "history", "like"])
+
+    assert result == 1
+    assert "init" in capsys.readouterr().err
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+python3 -m pytest tests/test_prefs.py::test_set_updates_value -v
+```
+Expected: FAIL.
+
+**Step 3: Implement `set`**
+
+Add to `scripts/prefs.py`:
+
+```python
+def cmd_set(args: argparse.Namespace) -> int:
+    if not PREFS_PATH.exists():
+        print(f"No prefs file found. Run: prefs.py init", file=sys.stderr)
+        return 1
+    if args.value not in VALUE_MAP:
+        print(f"Invalid value: {args.value!r}. Must be one of: like, neutral, dislike", file=sys.stderr)
+        return 1
+    vocab = _load_vocab()
+    if args.dimension not in vocab:
+        print(f"Unknown dimension: {args.dimension!r}. Valid: {sorted(vocab)}", file=sys.stderr)
+        return 1
+    if args.tag not in vocab[args.dimension]:
+        print(f"Unknown tag: {args.tag!r}. Valid for {args.dimension!r}: {sorted(vocab[args.dimension])}", file=sys.stderr)
+        return 1
+    try:
+        data = json.loads(PREFS_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Cannot read prefs: {exc}", file=sys.stderr)
+        return 1
+    data.setdefault(args.dimension, {})[args.tag] = VALUE_MAP[args.value]
+    _atomic_write(PREFS_PATH, data)
+    print(f"Set {args.dimension}.{args.tag} = {args.value}")
+    return 0
+```
+
+Wire into `main()`:
+
+```python
+    set_p = sub.add_parser("set", help="Set preference for a tag")
+    set_p.add_argument("dimension")
+    set_p.add_argument("tag")
+    set_p.add_argument("value", choices=list(VALUE_MAP))
+    # ...
+    if args.command == "set":
+        return cmd_set(args)
+```
+
+**Step 4: Run all tests**
+
+```bash
+python3 -m pytest tests/ -v
+```
+Expected: all PASS including pre-existing test suites.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/prefs.py tests/test_prefs.py
+git commit -m "feat: add set command to prefs CLI"
+```
+
+---
+
+### Task 6: Final check
+
+**Step 1: Run full test suite**
+
+```bash
+python3 -m pytest tests/ -v
+```
+Expected: all PASS.
+
+**Step 2: Smoke test the CLI manually**
+
+```bash
+python3 scripts/prefs.py init       # should fail — file already exists
+python3 scripts/prefs.py list
+python3 scripts/prefs.py get domain history
+python3 scripts/prefs.py set domain history like
+python3 scripts/prefs.py get domain history    # should print "like"
+python3 scripts/prefs.py list                  # should show history: like
+```
+
+**Step 3: Invoke superpowers:requesting-code-review**

--- a/scripts/prefs.py
+++ b/scripts/prefs.py
@@ -20,7 +20,11 @@ VALUE_MAP_INV = {v: k for k, v in VALUE_MAP.items()}
 
 
 def _load_vocab() -> dict[str, set[str]]:
-    return load_vocabulary(TAGS_CSV)
+    try:
+        return load_vocabulary(TAGS_CSV)
+    except OSError as exc:
+        print(f"Cannot load vocabulary: {exc}", file=sys.stderr)
+        raise SystemExit(1)
 
 
 def _atomic_write(path: Path, data: dict) -> None:

--- a/scripts/prefs.py
+++ b/scripts/prefs.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""CLI for reading and writing dyk-prefs.json."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from write_tags import load_vocabulary
+from helpers import PREFS_PATH
+
+TAGS_CSV = Path(__file__).parent.parent / "tagging" / "tags.csv"
+
+VALUE_MAP = {"like": 1, "neutral": 0, "dislike": -1}
+VALUE_MAP_INV = {v: k for k, v in VALUE_MAP.items()}
+
+
+def _load_vocab() -> dict[str, set[str]]:
+    return load_vocabulary(TAGS_CSV)
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    try:
+        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.rename(path)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    if PREFS_PATH.exists():
+        print(f"dyk-prefs.json already exists at {PREFS_PATH}", file=sys.stderr)
+        return 1
+    vocab = _load_vocab()
+    data = {dim: {tag: 0 for tag in sorted(tags)} for dim, tags in sorted(vocab.items())}
+    _atomic_write(PREFS_PATH, data)
+    print(f"Created {PREFS_PATH}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Manage DYK preferences.")
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("init", help="Create prefs file (fails if already exists)")
+    args = parser.parse_args(argv)
+    if args.command is None:
+        parser.print_help()
+        return 1
+    if args.command == "init":
+        return cmd_init(args)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prefs.py
+++ b/scripts/prefs.py
@@ -90,6 +90,28 @@ def cmd_get(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_set(args: argparse.Namespace) -> int:
+    if not PREFS_PATH.exists():
+        print(f"No prefs file found. Run: prefs.py init", file=sys.stderr)
+        return 1
+    vocab = _load_vocab()
+    if args.dimension not in vocab:
+        print(f"Unknown dimension: {args.dimension!r}. Valid: {sorted(vocab)}", file=sys.stderr)
+        return 1
+    if args.tag not in vocab[args.dimension]:
+        print(f"Unknown tag: {args.tag!r}. Valid for {args.dimension!r}: {sorted(vocab[args.dimension])}", file=sys.stderr)
+        return 1
+    try:
+        data = json.loads(PREFS_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Cannot read prefs: {exc}", file=sys.stderr)
+        return 1
+    data.setdefault(args.dimension, {})[args.tag] = VALUE_MAP[args.value]
+    _atomic_write(PREFS_PATH, data)
+    print(f"Set {args.dimension}.{args.tag} = {args.value}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Manage DYK preferences.")
     sub = parser.add_subparsers(dest="command")
@@ -98,7 +120,15 @@ def main(argv: list[str] | None = None) -> int:
     get_p = sub.add_parser("get", help="Get preference for a tag")
     get_p.add_argument("dimension")
     get_p.add_argument("tag")
-    args = parser.parse_args(argv)
+    set_p = sub.add_parser("set", help="Set preference for a tag")
+    set_p.add_argument("dimension")
+    set_p.add_argument("tag")
+    set_p.add_argument("value", choices=list(VALUE_MAP))
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        code = exc.code if exc.code is not None else 1
+        return 1 if code != 0 else 0
     if args.command is None:
         parser.print_help()
         return 1
@@ -108,6 +138,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_list(args)
     if args.command == "get":
         return cmd_get(args)
+    if args.command == "set":
+        return cmd_set(args)
     return 1
 
 

--- a/scripts/prefs.py
+++ b/scripts/prefs.py
@@ -124,6 +124,7 @@ def main(argv: list[str] | None = None) -> int:
     set_p.add_argument("dimension")
     set_p.add_argument("tag")
     set_p.add_argument("value", choices=list(VALUE_MAP))
+    # Catch argparse's SystemExit(2) on invalid args and normalise to return code 1.
     try:
         args = parser.parse_args(argv)
     except SystemExit as exc:

--- a/scripts/prefs.py
+++ b/scripts/prefs.py
@@ -69,11 +69,35 @@ def cmd_list(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_get(args: argparse.Namespace) -> int:
+    if not PREFS_PATH.exists():
+        print(f"No prefs file found. Run: prefs.py init", file=sys.stderr)
+        return 1
+    vocab = _load_vocab()
+    if args.dimension not in vocab:
+        print(f"Unknown dimension: {args.dimension!r}. Valid: {sorted(vocab)}", file=sys.stderr)
+        return 1
+    if args.tag not in vocab[args.dimension]:
+        print(f"Unknown tag: {args.tag!r}. Valid for {args.dimension!r}: {sorted(vocab[args.dimension])}", file=sys.stderr)
+        return 1
+    try:
+        data = json.loads(PREFS_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Cannot read prefs: {exc}", file=sys.stderr)
+        return 1
+    val = (data.get(args.dimension) or {}).get(args.tag, 0)
+    print(VALUE_MAP_INV.get(val, str(val)))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Manage DYK preferences.")
     sub = parser.add_subparsers(dest="command")
     sub.add_parser("init", help="Create prefs file (fails if already exists)")
     sub.add_parser("list", help="Show all current preferences")
+    get_p = sub.add_parser("get", help="Get preference for a tag")
+    get_p.add_argument("dimension")
+    get_p.add_argument("tag")
     args = parser.parse_args(argv)
     if args.command is None:
         parser.print_help()
@@ -82,6 +106,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_init(args)
     if args.command == "list":
         return cmd_list(args)
+    if args.command == "get":
+        return cmd_get(args)
     return 1
 
 

--- a/scripts/prefs.py
+++ b/scripts/prefs.py
@@ -58,6 +58,9 @@ def cmd_list(args: argparse.Namespace) -> int:
     except (json.JSONDecodeError, OSError) as exc:
         print(f"Cannot read prefs: {exc}", file=sys.stderr)
         return 1
+    if not isinstance(data, dict):
+        print(f"Prefs file is malformed (expected a JSON object)", file=sys.stderr)
+        return 1
     for dim, tags in sorted(data.items()):
         print(f"{dim}:")
         for tag, val in sorted(tags.items()):

--- a/scripts/prefs.py
+++ b/scripts/prefs.py
@@ -49,16 +49,36 @@ def cmd_init(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_list(args: argparse.Namespace) -> int:
+    if not PREFS_PATH.exists():
+        print(f"No prefs file found. Run: prefs.py init", file=sys.stderr)
+        return 1
+    try:
+        data = json.loads(PREFS_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Cannot read prefs: {exc}", file=sys.stderr)
+        return 1
+    for dim, tags in sorted(data.items()):
+        print(f"{dim}:")
+        for tag, val in sorted(tags.items()):
+            word = VALUE_MAP_INV.get(val, str(val))
+            print(f"  {tag}: {word}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Manage DYK preferences.")
     sub = parser.add_subparsers(dest="command")
     sub.add_parser("init", help="Create prefs file (fails if already exists)")
+    sub.add_parser("list", help="Show all current preferences")
     args = parser.parse_args(argv)
     if args.command is None:
         parser.print_help()
         return 1
     if args.command == "init":
         return cmd_init(args)
+    if args.command == "list":
+        return cmd_list(args)
     return 1
 
 

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -50,6 +50,11 @@ def test_init_creates_file(tmp_path, monkeypatch):
     assert result == 0
     data = json.loads(prefs_path.read_text())
     assert data == {"domain": {"history": 0, "science": 0}, "tone": {"straight": 0, "surprising": 0}}
+    raw = prefs_path.read_text()
+    parsed = json.loads(raw)
+    assert list(parsed.keys()) == sorted(parsed.keys())
+    for dim_tags in parsed.values():
+        assert list(dim_tags.keys()) == sorted(dim_tags.keys())
 
 
 def test_init_refuses_if_file_exists(tmp_path, monkeypatch, capsys):

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -68,3 +68,38 @@ def test_init_refuses_if_file_exists(tmp_path, monkeypatch, capsys):
 
     assert result == 1
     assert "already exists" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+def _write_prefs(path, data):
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_list_prints_prefs(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 1, "science": -1}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["list"])
+
+    out = capsys.readouterr().out
+    assert result == 0
+    assert "history" in out
+    assert "like" in out
+    assert "science" in out
+    assert "dislike" in out
+
+
+def test_list_missing_file_suggests_init(tmp_path, monkeypatch, capsys):
+    prefs_path = tmp_path / "dyk-prefs.json"
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+
+    result = prefs.main(["list"])
+
+    assert result == 1
+    assert "init" in capsys.readouterr().err

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -93,6 +93,7 @@ def test_list_prints_prefs(tmp_path, monkeypatch, capsys):
     assert "like" in out
     assert "science" in out
     assert "dislike" in out
+    assert "neutral" in out
 
 
 def test_list_missing_file_suggests_init(tmp_path, monkeypatch, capsys):

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -159,3 +159,87 @@ def test_get_missing_file_suggests_init(tmp_path, monkeypatch, capsys):
 
     assert result == 1
     assert "init" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# set
+# ---------------------------------------------------------------------------
+
+def test_set_updates_value(tmp_path, monkeypatch):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0, "science": 0}, "tone": {"straight": 0, "surprising": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["set", "domain", "history", "like"])
+
+    assert result == 0
+    data = json.loads(prefs_path.read_text())
+    assert data["domain"]["history"] == 1
+    assert data["domain"]["science"] == 0  # untouched
+
+
+def test_set_dislike(tmp_path, monkeypatch):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["set", "domain", "history", "dislike"])
+
+    assert result == 0
+    data = json.loads(prefs_path.read_text())
+    assert data["domain"]["history"] == -1
+
+
+def test_set_invalid_value(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["set", "domain", "history", "love"])
+
+    assert result == 1
+    assert "like" in capsys.readouterr().err
+
+
+def test_set_unknown_dimension(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["set", "badDim", "history", "like"])
+
+    assert result == 1
+    assert "Unknown dimension" in capsys.readouterr().err
+
+
+def test_set_unknown_tag(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["set", "domain", "badTag", "like"])
+
+    assert result == 1
+    assert "Unknown tag" in capsys.readouterr().err
+
+
+def test_set_missing_file_suggests_init(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["set", "domain", "history", "like"])
+
+    assert result == 1
+    assert "init" in capsys.readouterr().err

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -104,3 +104,58 @@ def test_list_missing_file_suggests_init(tmp_path, monkeypatch, capsys):
 
     assert result == 1
     assert "init" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+def test_get_returns_word(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 1}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["get", "domain", "history"])
+
+    assert result == 0
+    assert "like" in capsys.readouterr().out
+
+
+def test_get_unknown_dimension(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["get", "badDim", "history"])
+
+    assert result == 1
+    assert "Unknown dimension" in capsys.readouterr().err
+
+
+def test_get_unknown_tag(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    _write_prefs(prefs_path, {"domain": {"history": 0}, "tone": {"straight": 0}})
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["get", "domain", "badTag"])
+
+    assert result == 1
+    assert "Unknown tag" in capsys.readouterr().err
+
+
+def test_get_missing_file_suggests_init(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["get", "domain", "history"])
+
+    assert result == 1
+    assert "init" in capsys.readouterr().err

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/prefs.py.
+
+Run with: python3 -m pytest tests/ -v
+Requires: pip install pytest
+"""
+import csv
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import prefs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_vocab_csv(tmp_path):
+    rows = [
+        ("history",    "domain", "History"),
+        ("science",    "domain", "Science"),
+        ("surprising", "tone",   "Surprising"),
+        ("straight",   "tone",   "Straight"),
+    ]
+    p = tmp_path / "tags.csv"
+    with p.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["tag_id", "dimension", "description"])
+        writer.writerows(rows)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+
+def test_init_creates_file(tmp_path, monkeypatch):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["init"])
+
+    assert result == 0
+    data = json.loads(prefs_path.read_text())
+    assert data == {"domain": {"history": 0, "science": 0}, "tone": {"straight": 0, "surprising": 0}}
+
+
+def test_init_refuses_if_file_exists(tmp_path, monkeypatch, capsys):
+    vocab = _make_vocab_csv(tmp_path)
+    prefs_path = tmp_path / "dyk-prefs.json"
+    prefs_path.write_text("{}")
+    monkeypatch.setattr(prefs, "PREFS_PATH", prefs_path)
+    monkeypatch.setattr(prefs, "TAGS_CSV", vocab)
+
+    result = prefs.main(["init"])
+
+    assert result == 1
+    assert "already exists" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Adds `scripts/prefs.py` — a validated CLI for reading and writing `dyk-prefs.json` with four commands: `init`, `list`, `get`, `set`
- Values are expressed as words (`like`/`neutral`/`dislike`) rather than raw integers, preventing out-of-range input from LLMs or users
- All dimension and tag names validated against `tags.csv` vocabulary before writing; atomic save on every update
- 14 new tests, all 187 tests passing

## Test Plan

- [x] `python3 scripts/prefs.py init` — fails if file already exists, creates it with all values neutral if not
- [x] `python3 scripts/prefs.py list` — prints all prefs grouped by dimension with human-readable values
- [x] `python3 scripts/prefs.py get domain history` — prints current word for a tag
- [x] `python3 scripts/prefs.py set domain history like` — updates tag, verifiable with `get`
- [x] `python3 scripts/prefs.py set domain badtag like` — exits 1 with "Unknown tag" message
- [x] `python3 -m pytest tests/ -v` — 187 passed